### PR TITLE
Additional keyboard interrupt handling options

### DIFF
--- a/questionary/question.py
+++ b/questionary/question.py
@@ -10,6 +10,34 @@ from questionary import utils
 from questionary.constants import DEFAULT_KBI_MESSAGE
 
 
+def handle_kbi(
+    kbi_msg: str | None = DEFAULT_KBI_MESSAGE,
+    raise_on_kbi: bool = False,
+    exit_on_kbi: bool = False,
+) -> None:
+    """Handle a KeyboardInterrupt received during a prompt. Called in all prompting methods in :class:`Question` when
+    a KeyboardInterrupt is received
+
+    Args:
+
+        kbi_msg: The message to be printed on a keyboard interrupt (or None to not print a message).
+
+        raise_on_kbi: Raise KeyboardInterrupt when one is received in a prompt if True
+
+        exit_on_kbi: Exit the program when a KeyboardInterrupt is received in a prompt if True
+    """
+    if exit_on_kbi is True:
+        exit(0)
+    elif (not isinstance(exit_on_kbi, bool)) and isinstance(exit_on_kbi, int):
+        exit(exit_on_kbi)
+    elif raise_on_kbi:
+        raise KeyboardInterrupt()
+    else:
+        if kbi_msg:
+            print(f"\n{kbi_msg}\n")
+        return None
+
+
 class Question:
     """A question to be prompted.
 
@@ -26,7 +54,11 @@ class Question:
         self.default = None
 
     async def ask_async(
-        self, patch_stdout: bool = False, kbi_msg: str | None = DEFAULT_KBI_MESSAGE
+        self,
+        patch_stdout: bool = False,
+        kbi_msg: str | None = DEFAULT_KBI_MESSAGE,
+        raise_on_kbi: bool = False,
+        exit_on_kbi: bool = False,
     ) -> Any:
         """Ask the question using asyncio and return user response.
 
@@ -36,6 +68,10 @@ class Question:
 
             kbi_msg: The message to be printed on a keyboard interrupt (or None to not print a message).
 
+            raise_on_kbi: Raise KeyboardInterrupt when one is received in a prompt if True
+
+            exit_on_kbi: Exit the program when a KeyboardInterrupt is received in a prompt if True
+
         Returns:
             `Any`: The answer from the question.
         """
@@ -44,12 +80,16 @@ class Question:
             sys.stdout.flush()
             return await self.unsafe_ask_async(patch_stdout)
         except KeyboardInterrupt:
-            if kbi_msg:
-                print("\n{}\n".format(kbi_msg))
-            return None
+            return handle_kbi(
+                kbi_msg=kbi_msg, exit_on_kbi=exit_on_kbi, raise_on_kbi=raise_on_kbi
+            )
 
     def ask(
-        self, patch_stdout: bool = False, kbi_msg: str | None = DEFAULT_KBI_MESSAGE
+        self,
+        patch_stdout: bool = False,
+        kbi_msg: str | None = DEFAULT_KBI_MESSAGE,
+        raise_on_kbi: bool = False,
+        exit_on_kbi: bool = False,
     ) -> Any:
         """Ask the question synchronously and return user response.
 
@@ -59,6 +99,10 @@ class Question:
 
             kbi_msg: The message to be printed on a keyboard interrupt (or None to not print a message).
 
+            raise_on_kbi: Raise KeyboardInterrupt when one is received in a prompt if True
+
+            exit_on_kbi: Exit the program when a KeyboardInterrupt is received in a prompt if True
+
         Returns:
             `Any`: The answer from the question.
         """
@@ -66,9 +110,9 @@ class Question:
         try:
             return self.unsafe_ask(patch_stdout)
         except KeyboardInterrupt:
-            if kbi_msg:
-                print("\n{}\n".format(kbi_msg))
-            return None
+            return handle_kbi(
+                kbi_msg=kbi_msg, exit_on_kbi=exit_on_kbi, raise_on_kbi=raise_on_kbi
+            )
 
     def unsafe_ask(self, patch_stdout: bool = False) -> Any:
         """Ask the question synchronously and return user response.


### PR DESCRIPTION
Add more options for handling KeyboardInterrupts. `Question.ask()` and `Question.ask_async()` now accept args:
- `exit_on_kbi`: exit the program if user hits Ctrl-C
- `raise_on_kbi`: raise a `KeyboardInterrupt` exception if user hits Ctrl-C

This allows for more customization of behavior when the user decides to quit a prompt

Additionally, `kbi_msg` arg can be `None` to skip printing a message when Ctrl-C is hit by user